### PR TITLE
network errors should be passed to callbacks.

### DIFF
--- a/lib/Paypal.coffee
+++ b/lib/Paypal.coffee
@@ -148,7 +148,7 @@ class Paypal
       if response['ACK'] is 'Failure'
         callback response['L_LONGMESSAGE0']
       else
-        callback null, response
+        callback err, response
 
   # Returns subscription information for an already created subscription by
   # invoking the "GetRecurringPaymentsProfileDetails" method in the PayPal API.
@@ -182,7 +182,7 @@ class Paypal
       if response['ACK'] is 'Failure'
         callback response['L_LONGMESSAGE0']
       else
-        callback null, response
+        callback err, response
 
   # Modifies the state of an existing subscription by invoking the
   # ManageRecurringPaymentsProfileStatus on the PayPal API.
@@ -223,7 +223,7 @@ class Paypal
       if response['ACK'] is 'Failure'
         callback response['L_LONGMESSAGE0']
       else
-        callback null, response
+        callback err, response
 
   # Performs the actual API request to the PayPal API endpoint.
   #

--- a/lib/Paypal.coffee
+++ b/lib/Paypal.coffee
@@ -145,7 +145,7 @@ class Paypal
 
     @makeAPIrequest @getParams(opts), (err, response) ->
 
-      if response['ACK'] is 'Failure'
+      if response and response['ACK'] is 'Failure'
         callback response['L_LONGMESSAGE0']
       else
         callback err, response
@@ -175,11 +175,9 @@ class Paypal
       PROFILEID: id
     )
 
-
-
     @makeAPIrequest params, (err, response) ->
 
-      if response['ACK'] is 'Failure'
+      if response and response['ACK'] is 'Failure'
         callback response['L_LONGMESSAGE0']
       else
         callback err, response
@@ -220,7 +218,7 @@ class Paypal
 
     @makeAPIrequest params, (err, response) ->
 
-      if response['ACK'] is 'Failure'
+      if response and response['ACK'] is 'Failure'
         callback response['L_LONGMESSAGE0']
       else
         callback err, response


### PR DESCRIPTION
this PR doesn't do anything bad, but saves the cases in which `@makeAPIrequest` would call the callback with an `err != null`. For all other cases (in which `err == null`) nothing is different.
